### PR TITLE
Filter settings as search params

### DIFF
--- a/src/components/Guidelines/Guidelines.tsx
+++ b/src/components/Guidelines/Guidelines.tsx
@@ -19,9 +19,10 @@ export const Guidelines = () => {
     isLoading,
     isError,
   } = useGuidelines();
+  const filterPickerConfig = getFilterPickerConfig({ categories, tags });
   const [searchString, setSearchString] = useState("");
   const { activeFilters, addFilter, removeFilter, removeAllFilters } =
-    useFilters();
+    useFilters(filterPickerConfig);
   const filteredGuidelines = useFilteredGuidelines({
     activeFilters,
     guidelines,
@@ -46,7 +47,7 @@ export const Guidelines = () => {
           onChange={setSearchString}
         />
         <div className={styles.filterPickers}>
-          {getFilterPickerConfig({ categories, tags }).map(
+          {filterPickerConfig.map(
             ({ align, contentStyle, filters, label, type }) => {
               const numActiveFilters = activeFilters.filter(
                 (filter) => filter.type === type

--- a/src/components/Guidelines/utils/getFilterPickerConfig.ts
+++ b/src/components/Guidelines/utils/getFilterPickerConfig.ts
@@ -1,14 +1,5 @@
-import { CSSProperties } from "react";
-import { Filter, FilterType } from "../../../models/filter";
 import { Level } from "../../../models/level";
-
-interface FilterPickerConfig {
-  align?: "start" | "end";
-  contentStyle?: CSSProperties;
-  label: string;
-  filters: Omit<Filter, "type">[];
-  type: FilterType;
-}
+import { FilterGroup } from "./types";
 
 export const getFilterPickerConfig = ({
   categories,
@@ -16,7 +7,7 @@ export const getFilterPickerConfig = ({
 }: {
   categories: { id: string; title: string }[];
   tags: string[];
-}): FilterPickerConfig[] => [
+}): FilterGroup[] => [
   {
     label: "Categories",
     type: "category",

--- a/src/components/Guidelines/utils/types.ts
+++ b/src/components/Guidelines/utils/types.ts
@@ -1,0 +1,10 @@
+import { CSSProperties } from "react";
+import { Filter, FilterType } from "../../../models/filter";
+
+export interface FilterGroup {
+  align?: "start" | "end";
+  contentStyle?: CSSProperties;
+  label: string;
+  filters: Omit<Filter, "type">[];
+  type: FilterType;
+}

--- a/src/components/Guidelines/utils/useFilters.ts
+++ b/src/components/Guidelines/utils/useFilters.ts
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Filter } from "../../../models/filter";
+import { FilterGroup } from "./types";
 
-export const useFilters = () => {
-  const [activeFilters, setActiveFilters] = useState<Filter[]>([]);
+export const useFilters = (filterPickerConfig: FilterGroup[]) => {
+  const { activeFilters, setActiveFilters } =
+    useActiveFilters(filterPickerConfig);
 
   const addFilter = (filter: Filter) => {
     setActiveFilters([...activeFilters, filter]);
@@ -21,4 +23,62 @@ export const useFilters = () => {
     removeFilter,
     removeAllFilters: () => setActiveFilters([]),
   };
+};
+
+// Help functions to handle filter state as search params
+const useSearchParams = () => {
+  const [searchParams, setSearchParams] = useState(
+    new URLSearchParams(window.location.search)
+  );
+
+  return {
+    searchParams,
+    setSearchParams: (searchParams: URLSearchParams) => {
+      const url = searchParams.toString().length
+        ? `?${searchParams.toString()}`
+        : location.pathname;
+      window.history.replaceState(null, "", url);
+
+      setSearchParams(new URLSearchParams(searchParams));
+    },
+  };
+};
+
+const useActiveFilters = (config: FilterGroup[]) => {
+  const { searchParams, setSearchParams } = useSearchParams();
+
+  const activeFilters = config
+    .map((filterGroup) => {
+      const values = searchParams.getAll(filterGroup.type);
+
+      const filters = values
+        .map((value) => {
+          const config = filterGroup.filters.find(
+            (f) => `${f.value}`.toLowerCase() === value.toLowerCase()
+          );
+
+          return config
+            ? {
+                ...config,
+                type: filterGroup.type,
+              }
+            : undefined;
+        })
+        .filter((filter): filter is Filter => !!filter);
+
+      return filters;
+    })
+    .flat();
+
+  const setActiveFilters = (filters: Filter[]) => {
+    config.forEach((filterGroup) => {
+      searchParams.delete(filterGroup.type);
+    });
+    filters.forEach((filter) => {
+      searchParams.append(filter.type, `${filter.value}`.toLowerCase());
+    });
+    setSearchParams(searchParams);
+  };
+
+  return { activeFilters, setActiveFilters };
 };

--- a/src/components/Guidelines/utils/useFilters.ts
+++ b/src/components/Guidelines/utils/useFilters.ts
@@ -74,9 +74,11 @@ const useActiveFilters = (config: FilterGroup[]) => {
     config.forEach((filterGroup) => {
       searchParams.delete(filterGroup.type);
     });
-    filters.forEach((filter) => {
-      searchParams.append(filter.type, `${filter.value}`.toLowerCase());
-    });
+    filters
+      .sort((a, b) => a.type.localeCompare(b.type))
+      .forEach((filter) => {
+        searchParams.append(filter.type, `${filter.value}`.toLowerCase());
+      });
     setSearchParams(searchParams);
   };
 


### PR DESCRIPTION
Making filter settings part of URL search params. This will make the filtering stay if page is reloaded. Also it will make it possible to share links with pre defined filtering.

Fixes https://github.com/annavik/websustainability/issues/10

Example:
<img width="899" alt="Screenshot 2023-12-09 at 12 03 26" src="https://github.com/annavik/websustainability/assets/11680517/ba910123-faf3-41d1-ba0c-c4407c593d79">
