### PR TITLE
Suggestion: Update site name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Web Sustainability 4U
+# websustainability.io
 
 In October 2023, the [W3C Community](https://www.w3.org/groups/cg/sustyweb/) published the first draft of the [Web Sustainability Guidelines](https://w3c.github.io/sustyweb/) (WSG). This tool is an independent side project that offers a way to navigate and prioritize these guidelines. For the implementation we use TypeScript and React. Feel free to suggest features, report bugs or contribute!
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- HTML tags -->
-    <title>Web Sustainability 4U</title>
+    <title>websustainability.io</title>
     <meta
       name="description"
       content="An interactive version of Web Sustainability Guidelines (WSG) 1.0. Learn how to make web applications more sustainable, considering both environmental, social, and governance factors."
@@ -12,7 +12,7 @@
     <link rel="icon" type="image/svg+xml" href="/globe.svg" />
 
     <!-- Open Graph tags -->
-    <meta property="og:title" content="Web Sustainability 4U" />
+    <meta property="og:title" content="websustainability.io" />
     <meta
       property="og:description"
       content="An interactive version of Web Sustainability Guidelines (WSG) 1.0. Learn how to make web applications more sustainable, considering both environmental, social, and governance factors."
@@ -25,7 +25,7 @@
     <meta property="og:url" content="https://websustainability.io/" />
 
     <!-- Twitter tags -->
-    <meta name="twitter:title" content="Web Sustainability 4U" />
+    <meta name="twitter:title" content="websustainability.io" />
     <meta
       name="twitter:description"
       content="An interactive version of Web Sustainability Guidelines (WSG) 1.0. Learn how to make web applications more sustainable, considering both environmental, social, and governance factors."

--- a/src/components/AboutDialog/AboutDialog.tsx
+++ b/src/components/AboutDialog/AboutDialog.tsx
@@ -34,7 +34,7 @@ export const AboutDialog = ({ theme }: { theme: Theme }) => (
           </p>
         </div>
         <div className={styles.section}>
-          <h1>About Web Sustainability 4U</h1>
+          <h1>About websustainability.io</h1>
           <p>
             This tool is an independent side project that offers a way to
             navigate and prioritize the Web Sustainability Guidelines. When it

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -20,7 +20,7 @@ export const Header = () => {
         </div>
         <img src="./globe.svg" alt="" width={96} height={96} />
         <div>
-          <h1>Web Sustainability 4U</h1>
+          <h1>websustainability.io</h1>
           <h2>
             An interactive version of{" "}
             <a href="https://w3c.github.io/sustyweb/">WSG 1.0</a>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -18,7 +18,7 @@ export const Header = () => {
           <AboutDialog theme={theme} />
           <ThemeToggle theme={theme} onThemeChange={setTheme} />
         </div>
-        <img src="./globe.svg" alt="" width={96} height={96} />
+        <img src="./globe.svg" alt="websustainability.io logo." width={96} height={96} />
         <div>
           <h1>websustainability.io</h1>
           <h2>


### PR DESCRIPTION
Just a suggestion! :) I have noticed I tend to use just "websustainability.io" rather than "Web Sustainability 4U" when I talk about the site. What do you think @c0ldbear?

Also PR deploy previews are back up again, check it out so see how this name change could look like in practice 👇